### PR TITLE
DO NOT MERGE - do not leak connection file descriptors - delete connection from connection pool map only when connection is closed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -127,12 +127,18 @@ func (c *Conn) Close() {
 	}
 }
 
-func (c *Conn) Release() {
+func (c *Conn) Release() (closed bool) {
 	refCount := atomic.AddInt32(&c.refCount, -1)
-	if refCount == 0 && atomic.LoadInt32(&c.shutdown) == 1 {
+	shutdown := atomic.LoadInt32(&c.shutdown)
+	if refCount == 0 && shutdown == 1 {
 		sLog.Printf("Release: calling Close() %p %s\n", c, c)
 		c.Close()
+		return true
 	}
+
+	//	sLog.Printf("Release: not calling Close() %p for key %s with refCount: %d shutdown: %d\n",
+	//		c, c.key, refCount, shutdown)
+	return false
 }
 
 func (c *Conn) Hold() {

--- a/client/client.go
+++ b/client/client.go
@@ -136,8 +136,8 @@ func (c *Conn) Release() (closed bool) {
 		return true
 	}
 
-	//	sLog.Printf("Release: not calling Close() %p for key %s with refCount: %d shutdown: %d\n",
-	//		c, c.key, refCount, shutdown)
+	sLog.Printf("Release: not calling Close() %p for key %s with refCount: %d shutdown: %d\n",
+		c, c.key, refCount, shutdown)
 	return false
 }
 

--- a/client/pool.go
+++ b/client/pool.go
@@ -2,6 +2,7 @@ package rpc_client
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/rpc"
 	"strings"
@@ -139,13 +140,21 @@ func (p *ConnPool) getClnt(addr net.Addr, st string) (*Conn, error) {
 	if c == nil {
 		c, err = NewConn(p.newClientCodec, addr, st, key, p.timo, p.tlsConfig)
 		if err != nil {
-			//	sLog.WarnPrintf("newConn: %p for key %s error: %s", c, key, err)
+			sLog.WarnPrintf("newConn: %p for key %s error: %s", c, key, err)
 			return nil, err
 		}
-		//	sLog.Printf("newConn: %p for key %s", c, key)
+		sLog.Printf("newConn: %p for key %s", c, key)
 		c = p.addConn(c)
 	}
-	//	sLog.Printf("getClnt: %p for key %s  %s<==>%s", c, key, c.net_con.LocalAddr(), c.net_con.RemoteAddr())
+	connStr := "  Conn is nil"
+	if c != nil {
+		if c.net_con != nil {
+			connStr = fmt.Sprintf("%s<==>%s", c.net_con.LocalAddr(), c.net_con.RemoteAddr())
+		} else {
+			connStr = "  connection is nil"
+		}
+	}
+	sLog.Printf("getClnt: %p for key %s  %s", c, key, connStr)
 	return c, nil
 }
 

--- a/client/pool.go
+++ b/client/pool.go
@@ -114,9 +114,10 @@ func (p *ConnPool) Shutdown(conn *Conn) {
 	sLog.Printf("Shutdown: %p", p)
 	p.Lock()
 	if c, ok := p.pool[conn.key]; ok && c == conn {
-		delete(p.pool, conn.key)
 		c.Shutdown()
-		c.Release()
+		if c.Release() {
+			delete(p.pool, conn.key)
+		}
 	}
 	p.Unlock()
 }
@@ -138,10 +139,13 @@ func (p *ConnPool) getClnt(addr net.Addr, st string) (*Conn, error) {
 	if c == nil {
 		c, err = NewConn(p.newClientCodec, addr, st, key, p.timo, p.tlsConfig)
 		if err != nil {
+			//	sLog.WarnPrintf("newConn: %p for key %s error: %s", c, key, err)
 			return nil, err
 		}
+		//	sLog.Printf("newConn: %p for key %s", c, key)
 		c = p.addConn(c)
 	}
+	//	sLog.Printf("getClnt: %p for key %s  %s<==>%s", c, key, c.net_con.LocalAddr(), c.net_con.RemoteAddr())
 	return c, nil
 }
 


### PR DESCRIPTION
======== DO NOT MERGE - WORK IN PROGRESS ===========

refs https://github.com/stackengine/controller/issues/2357

ISSUE - upon error:
- the map entry for the key for the connection is removed
- client shutdown for the connection is called
- client release for the connection is called
  - since there are more than 0 references (1)
  - the connection is not closed

leakage

```
[ admin              ] [ Debug  ] 2015/11/10 22:52:43 v2imagehandlers.go:50 API:  /api/v2/images/non-existent:latest/hosts/2f91a299-73ae-5493-d13e-f7de9dce2e24/pull
[ admin              ] [ Debug  ] 2015/11/10 22:52:43 v2imagehandlers.go:102 performing pull action for repo_id non-existent:latest
[ clntrpc            ] [ Debug  ] 2015/11/10 22:52:43 pool.go:138 ========= get Clnt: 0x0 for key 172.16.44.191:8001/REG
[ clntrpc            ] [ Debug  ] 2015/11/10 22:52:43 pool.go:144 ========= new conn: 0xc20898aa20 for key 172.16.44.191:8001/REG
[ svcrpc             ] [ Debug  ] 2015/11/10 22:52:43 server.go:232 Processing connection from 172.16.44.191:45135
[ clntrpc            ] [ Debug  ] 2015/11/10 22:52:43 pool.go:147 ========= get Clnt: 0xc20898aa20 for key 172.16.44.191:8001/REG  172.16.44.191:45135<==>172.16.44.191:8001
[ clntrpc            ] [ Debug  ] 2015/11/10 22:52:43 pool.go:138 ========= get Clnt: 0xc20898aa20 for key 172.16.44.191:8001/REG
[ clntrpc            ] [ Debug  ] 2015/11/10 22:52:43 pool.go:147 ========= get Clnt: 0xc20898aa20 for key 172.16.44.191:8001/REG  172.16.44.191:45135<==>172.16.44.191:8001
[ status-sender      ] [ Debug  ] 2015/11/10 22:52:44 sender.go:100 sent 1 events

[ wharf              ] [ Warn   ] 2015/11/10 22:52:45 image_server.go:50 pull image non-existent:latest on host mesh-02 due to error: Error: image library/non-existent:latest not found
[ clntrpc            ] [ Debug  ] 2015/11/10 22:52:45 pool.go:114 Shutdown: 0xc2084a6cc0
[ clntrpc            ] [ Debug  ] 2015/11/10 22:52:45 client.go:136 ========= not closing 0xc20898aa20 - refCount: 2  shutdown: 1
[ clntrpc            ] [ Debug  ] 2015/11/10 22:52:45 pool.go:169 error on Call():  Error: image library/non-existent:latest not found
[ clntrpc            ] [ Debug  ] 2015/11/10 22:52:45 client.go:136 ========= not closing 0xc20898aa20 - refCount: 1  shutdown: 1

[ storelib           ] [ Debug  ] 2015/11/10 22:52:46 fts.go:16 indexing status.Record:task|6affd2c4-15c6-4dbe-a23c-cd855c5d3dd8|||container_state
[ status-sender      ] [ Debug  ] 2015/11/10 22:52:46 sender.go:100 sent 2 events
```
